### PR TITLE
配線修正

### DIFF
--- a/bl_motor_dora3/bl_dora2.brd
+++ b/bl_motor_dora3/bl_dora2.brd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.4.2">
+<eagle version="9.5.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -1705,18 +1705,6 @@ Source: PANASONIC .. aoc0000ce1.pdf</description>
 <wire x1="7.4" y1="5.75" x2="7.4" y2="0" width="0.127" layer="21"/>
 <wire x1="7.4" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
 </package>
-<package name="1608REG">
-<description>1608サイズのチップ抵抗　多分ガッコのリールチップ抵抗はこのサイズ</description>
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-<text x="-1.27" y="1.27" size="0.4064" layer="25">&gt;NAME</text>
-<text x="-1.27" y="0.762" size="0.4064" layer="27">&gt;VALUE</text>
-</package>
 <package name="ES3BB13F" urn="urn:adsk.eagle:footprint:43181/1" locally_modified="yes">
 <description>&lt;B&gt;DIODE&lt;/B&gt;</description>
 <wire x1="-2.2606" y1="1.905" x2="2.2606" y2="1.905" width="0.1016" layer="21"/>
@@ -2232,14 +2220,6 @@ design rules under a new name.</description>
 <attribute name="SPICEPREFIX" value="C" x="61.849" y="27.559" size="1.778" layer="28" rot="MR270" display="off"/>
 <attribute name="VALUE" x="64.389" y="28.829" size="1.27" layer="28" rot="MR270"/>
 </element>
-<element name="R33" library="user" package="1608REG" value="0" x="34.29" y="14.097" smashed="yes" rot="MR270">
-<attribute name="NAME" x="33.02" y="15.367" size="0.4064" layer="26" rot="MR270"/>
-<attribute name="VALUE" x="33.528" y="15.367" size="0.4064" layer="28" rot="MR270"/>
-</element>
-<element name="R34" library="user" package="1608REG" value="0" x="29.21" y="14.097" smashed="yes" rot="MR270">
-<attribute name="NAME" x="27.94" y="15.367" size="0.4064" layer="26" rot="MR270"/>
-<attribute name="VALUE" x="28.448" y="15.367" size="0.4064" layer="28" rot="MR270"/>
-</element>
 <element name="U$20" library="user" package="ES3BB13F" value="ES3BB13F" x="59.055" y="35.306" smashed="yes" rot="R270">
 <attribute name="NAME" x="61.214" y="37.465" size="1.27" layer="25" rot="R270"/>
 <attribute name="VALUE" x="55.626" y="37.465" size="1.27" layer="27" rot="R270"/>
@@ -2312,6 +2292,13 @@ design rules under a new name.</description>
 <polygon width="0.1524" layer="1" thermals="no">
 <vertex x="25.019" y="40.259"/>
 <vertex x="32.258" y="40.259"/>
+<vertex x="32.258" y="19.431"/>
+<vertex x="31.877" y="19.05"/>
+<vertex x="31.75" y="19.05"/>
+<vertex x="30.48" y="19.05"/>
+<vertex x="30.48" y="16.51"/>
+<vertex x="31.75" y="16.51"/>
+<vertex x="32.258" y="16.002"/>
 <vertex x="32.258" y="0"/>
 <vertex x="24.13" y="0"/>
 <vertex x="24.13" y="33.02"/>
@@ -2322,8 +2309,8 @@ design rules under a new name.</description>
 <vertex x="19.431" y="34.671"/>
 <vertex x="25.019" y="40.259"/>
 <vertex x="32.258" y="40.259"/>
-<vertex x="32.258" y="0"/>
-<vertex x="24.13" y="0"/>
+<vertex x="32.258" y="23.241"/>
+<vertex x="24.13" y="23.241"/>
 <vertex x="24.13" y="29.21"/>
 <vertex x="19.431" y="29.21"/>
 </polygon>
@@ -2338,8 +2325,7 @@ design rules under a new name.</description>
 <wire x1="29.077" y1="32.131" x2="29.077" y2="27.432" width="0.3048" layer="1"/>
 <wire x1="29.077" y1="27.432" x2="29.077" y2="22.479" width="0.3048" layer="1"/>
 <wire x1="29.077" y1="22.479" x2="29.077" y2="17.653" width="0.3048" layer="1"/>
-<wire x1="29.077" y1="17.653" x2="29.08" y2="17.65" width="0.3048" layer="1"/>
-<wire x1="29.08" y1="17.65" x2="30.48" y2="16.25" width="0.3048" layer="1"/>
+<wire x1="29.077" y1="17.653" x2="30.48" y2="16.25" width="0.3048" layer="1"/>
 <wire x1="30.48" y1="12.039" x2="30.898" y2="11.621" width="0.3048" layer="1"/>
 <wire x1="30.48" y1="16.25" x2="30.48" y2="12.039" width="0.3048" layer="1"/>
 <wire x1="30.898" y1="6.448" x2="30.898" y2="11.621" width="0.1524" layer="1"/>
@@ -2356,8 +2342,6 @@ design rules under a new name.</description>
 <via x="31.75" y="13.97" extent="1-16" drill="0.35"/>
 <via x="25.4" y="15.24" extent="1-16" drill="0.35"/>
 <via x="26.67" y="15.24" extent="1-16" drill="0.35"/>
-<via x="31.75" y="19.05" extent="1-16" drill="0.35"/>
-<via x="31.75" y="21.59" extent="1-16" drill="0.35"/>
 <via x="31.75" y="22.86" extent="1-16" drill="0.35"/>
 <via x="31.75" y="26.67" extent="1-16" drill="0.35"/>
 <via x="31.75" y="27.94" extent="1-16" drill="0.35"/>
@@ -2368,12 +2352,29 @@ design rules under a new name.</description>
 <wire x1="26.91" y1="4.84" x2="26.67" y2="5.08" width="0.1524" layer="1"/>
 <wire x1="29.29" y1="4.84" x2="26.91" y2="4.84" width="0.1524" layer="1"/>
 <wire x1="29.29" y1="4.84" x2="30.898" y2="6.448" width="0.1524" layer="1"/>
-<contactref element="R34" pad="1"/>
-<wire x1="29.21" y1="14.947" x2="28.917" y2="15.24" width="0.1524" layer="16"/>
-<wire x1="28.917" y1="15.24" x2="27.94" y2="15.24" width="0.1524" layer="16"/>
-<via x="27.94" y="15.24" extent="1-16" drill="0.35"/>
-<wire x1="27.94" y1="15.24" x2="27.94" y2="16.51" width="0.1524" layer="1"/>
-<wire x1="27.94" y1="16.51" x2="29.08" y2="17.65" width="0.1524" layer="1"/>
+<via x="32.258" y="17.145" extent="1-16" drill="0.35"/>
+<wire x1="29.077" y1="17.653" x2="29.585" y2="17.145" width="0.1524" layer="1"/>
+<wire x1="32.258" y1="17.145" x2="29.585" y2="17.145" width="0.1524" layer="1"/>
+<contactref element="U$1" pad="PIN21"/>
+<wire x1="16.49" y1="21.15" x2="16.51" y2="21.13" width="0.1524" layer="1"/>
+<wire x1="16.51" y1="19.05" x2="16.383" y2="18.923" width="0.1524" layer="1"/>
+<wire x1="16.383" y1="18.923" x2="16.383" y2="18.07" width="0.1524" layer="1"/>
+<wire x1="16.383" y1="18.07" x2="16.8" y2="17.653" width="0.1524" layer="1"/>
+<via x="16.8" y="17.653" extent="1-16" drill="0.35"/>
+<wire x1="16.51" y1="21.13" x2="16.51" y2="19.05" width="0.1524" layer="1"/>
+<polygon width="0.1524" layer="16">
+<vertex x="24.13" y="0"/>
+<vertex x="32.258" y="0"/>
+<vertex x="32.258" y="16.129"/>
+<vertex x="24.13" y="16.129"/>
+</polygon>
+<wire x1="17.272" y1="17.526" x2="16.927" y2="17.526" width="0.1524" layer="16"/>
+<wire x1="16.8" y1="17.653" x2="16.927" y2="17.526" width="0.1524" layer="16"/>
+<wire x1="17.272" y1="17.526" x2="18.669" y2="16.129" width="0.1524" layer="16"/>
+<wire x1="18.669" y1="16.129" x2="22.606" y2="16.129" width="0.1524" layer="16"/>
+<wire x1="22.606" y1="16.129" x2="23.495" y2="17.018" width="0.1524" layer="16"/>
+<wire x1="32.131" y1="17.018" x2="32.258" y2="17.145" width="0.1524" layer="16"/>
+<wire x1="23.495" y1="17.018" x2="32.131" y2="17.018" width="0.1524" layer="16"/>
 </signal>
 <signal name="V5">
 <contactref element="U$1" pad="PIN4"/>
@@ -2527,7 +2528,7 @@ design rules under a new name.</description>
 <vertex x="7.62" y="38.1"/>
 </polygon>
 <wire x1="9.93" y1="29.36" x2="9.93" y2="32.11" width="0.1524" layer="16"/>
-<wire x1="17.99" y1="21.15" x2="26.44" y2="12.7" width="0.1524" layer="1"/>
+<wire x1="17.99" y1="21.15" x2="23.38" y2="15.76" width="0.1524" layer="1"/>
 <via x="20.32" y="39.37" extent="1-16" drill="0.35"/>
 <via x="21.59" y="40.64" extent="1-16" drill="0.35"/>
 <via x="22.86" y="40.64" extent="1-16" drill="0.35"/>
@@ -2545,11 +2546,11 @@ design rules under a new name.</description>
 <wire x1="33.498" y1="11.621" x2="33.498" y2="7.557" width="1.27" layer="1"/>
 <wire x1="36.49" y1="4.84" x2="36.215" y2="4.84" width="1.27" layer="1"/>
 <wire x1="36.215" y1="4.84" x2="33.498" y2="7.557" width="1.27" layer="1"/>
-<wire x1="27.614" y1="12.7" x2="26.67" y2="12.7" width="0.1524" layer="16"/>
-<via x="26.67" y="12.7" extent="1-16" drill="0.35"/>
-<wire x1="26.67" y1="12.7" x2="26.44" y2="12.7" width="0.1524" layer="1"/>
-<wire x1="36.49" y1="4.84" x2="35.474" y2="4.84" width="0.1524" layer="16"/>
-<wire x1="35.474" y1="4.84" x2="27.614" y2="12.7" width="0.1524" layer="16"/>
+<via x="23.368" y="15.748" extent="1-16" drill="0.35"/>
+<wire x1="23.368" y1="15.748" x2="23.38" y2="15.76" width="0.1524" layer="1"/>
+<wire x1="32.766" y1="4.84" x2="32.766" y2="16.51" width="0.1524" layer="16"/>
+<wire x1="32.766" y1="16.51" x2="24.13" y2="16.51" width="0.1524" layer="16"/>
+<wire x1="24.13" y1="16.51" x2="23.368" y2="15.748" width="0.1524" layer="16"/>
 <wire x1="28.829" y1="41.236" x2="28.155" y2="41.91" width="0.4064" layer="16"/>
 <wire x1="28.155" y1="41.91" x2="25.4" y2="41.91" width="0.4064" layer="16"/>
 <wire x1="22.86" y1="40.64" x2="24.13" y2="41.91" width="0.4064" layer="16"/>
@@ -2660,6 +2661,7 @@ design rules under a new name.</description>
 <wire x1="64.66094375" y1="32.131" x2="67.445" y2="32.131" width="1.016" layer="16"/>
 <wire x1="60.25305625" y1="32.131" x2="61.55445625" y2="33.4324" width="1.016" layer="16"/>
 <wire x1="63.35954375" y1="33.4324" x2="64.66094375" y2="32.131" width="1.016" layer="16"/>
+<wire x1="32.766" y1="4.84" x2="36.49" y2="4.84" width="0.1524" layer="16"/>
 </signal>
 <signal name="AGND">
 <contactref element="U$1" pad="PIN41"/>
@@ -3321,17 +3323,17 @@ design rules under a new name.</description>
 <wire x1="19.49" y1="26.15" x2="19.6008" y2="26.2608" width="0.1524" layer="1"/>
 <wire x1="19.6008" y1="26.2608" x2="20.76895" y2="26.2608" width="0.1524" layer="1"/>
 <via x="20.76895" y="26.2608" extent="1-16" drill="0.35"/>
-<wire x1="20.76895" y1="26.2608" x2="21.17815" y2="26.67" width="0.1524" layer="16"/>
-<wire x1="21.17815" y1="26.67" x2="25.4" y2="26.67" width="0.1524" layer="16"/>
-<via x="25.4" y="26.67" extent="1-16" drill="0.35"/>
 <wire x1="55.819" y1="44.704" x2="54.549" y2="45.974" width="0.1524" layer="16"/>
 <wire x1="54.549" y1="45.974" x2="40.513" y2="45.974" width="0.1524" layer="16"/>
-<wire x1="25.4" y1="29.21" x2="25.4" y2="30.48" width="0.1524" layer="16"/>
-<via x="25.4" y="29.21" extent="1-16" drill="0.35"/>
-<wire x1="25.4" y1="29.21" x2="25.4" y2="26.67" width="0.1524" layer="1"/>
-<wire x1="36.83" y1="41.91" x2="36.83" y2="42.291" width="0.1524" layer="16"/>
+<wire x1="36.83" y1="42.037" x2="36.83" y2="42.291" width="0.1524" layer="16"/>
 <wire x1="36.83" y1="42.291" x2="40.513" y2="45.974" width="0.1524" layer="16"/>
-<wire x1="25.4" y1="30.48" x2="36.83" y2="41.91" width="0.1524" layer="16"/>
+<wire x1="25.273" y1="30.48" x2="36.83" y2="42.037" width="0.1524" layer="16"/>
+<wire x1="20.76895" y1="26.2608" x2="18.923" y2="28.10675" width="0.1524" layer="16"/>
+<wire x1="18.923" y1="29.337" x2="19.177" y2="29.591" width="0.1524" layer="16"/>
+<wire x1="19.177" y1="29.591" x2="22.225" y2="29.591" width="0.1524" layer="16"/>
+<wire x1="22.225" y1="29.591" x2="23.114" y2="30.48" width="0.1524" layer="16"/>
+<wire x1="23.114" y1="30.48" x2="25.273" y2="30.48" width="0.1524" layer="16"/>
+<wire x1="18.923" y1="28.10675" x2="18.923" y2="29.337" width="0.1524" layer="16"/>
 </signal>
 <signal name="N$36">
 <contactref element="U$1" pad="PIN29"/>
@@ -3340,13 +3342,6 @@ design rules under a new name.</description>
 <wire x1="20.5578" y1="24.65" x2="20.574" y2="24.6662" width="0.1524" layer="1"/>
 <via x="20.574" y="24.6662" extent="1-16" drill="0.35"/>
 <wire x1="20.574" y1="24.6662" x2="23.3962" y2="24.6662" width="0.1524" layer="16"/>
-<wire x1="24.13" y1="25.4" x2="23.3962" y2="24.6662" width="0.1524" layer="16"/>
-<wire x1="29.21" y1="30.48" x2="26.67" y2="27.94" width="0.1524" layer="16"/>
-<wire x1="26.67" y1="27.94" x2="26.67" y2="26.67" width="0.1524" layer="16"/>
-<via x="26.67" y="26.67" extent="1-16" drill="0.35"/>
-<wire x1="26.67" y1="26.67" x2="25.4" y2="25.4" width="0.1524" layer="1"/>
-<via x="25.4" y="25.4" extent="1-16" drill="0.35"/>
-<wire x1="25.4" y1="25.4" x2="24.13" y2="25.4" width="0.1524" layer="16"/>
 <via x="39.37" y="32.385" extent="1-16" drill="0.35"/>
 <wire x1="40.7233125" y1="32.7786" x2="40.3297125" y2="32.385" width="0.1524" layer="16"/>
 <wire x1="40.3297125" y1="32.385" x2="39.37" y2="32.385" width="0.1524" layer="16"/>
@@ -3358,6 +3353,7 @@ design rules under a new name.</description>
 <wire x1="37.592" y1="30.48" x2="29.21" y2="30.48" width="0.1524" layer="16"/>
 <wire x1="46.2842875" y1="30.607" x2="58.486" y2="30.607" width="0.1524" layer="16"/>
 <wire x1="44.1126875" y1="32.7786" x2="46.2842875" y2="30.607" width="0.1524" layer="16"/>
+<wire x1="29.21" y1="30.48" x2="23.3962" y2="24.6662" width="0.1524" layer="16"/>
 </signal>
 <signal name="N$37">
 <contactref element="U$1" pad="PIN26"/>
@@ -3365,15 +3361,18 @@ design rules under a new name.</description>
 <wire x1="19.49" y1="23.15" x2="20.2306" y2="23.15" width="0.1524" layer="1"/>
 <wire x1="20.2306" y1="23.15" x2="20.5206" y2="22.86" width="0.1524" layer="1"/>
 <via x="20.5206" y="22.86" extent="1-16" drill="0.35"/>
-<via x="40.005" y="18.415" extent="1-16" drill="0.35"/>
-<wire x1="40.3986" y1="18.8086" x2="40.005" y2="18.415" width="0.1524" layer="16"/>
 <wire x1="44.1126875" y1="18.8086" x2="40.3986" y2="18.8086" width="0.1524" layer="16"/>
-<wire x1="40.005" y1="18.415" x2="38.1" y2="16.51" width="0.1524" layer="1"/>
-<via x="38.1" y="16.51" extent="1-16" drill="0.35"/>
-<wire x1="38.1" y1="16.51" x2="26.8706" y2="16.51" width="0.1524" layer="16"/>
-<wire x1="26.8706" y1="16.51" x2="20.5206" y2="22.86" width="0.1524" layer="16"/>
+<wire x1="38.1" y1="16.51" x2="35.052" y2="16.51" width="0.1524" layer="16"/>
+<wire x1="35.052" y1="16.51" x2="34.798" y2="16.764" width="0.1524" layer="16"/>
+<wire x1="34.798" y1="16.764" x2="34.798" y2="18.796" width="0.1524" layer="16"/>
+<wire x1="34.798" y1="18.796" x2="33.655" y2="19.939" width="0.1524" layer="16"/>
+<wire x1="33.655" y1="19.939" x2="30.988" y2="19.939" width="0.1524" layer="16"/>
+<wire x1="30.988" y1="19.939" x2="29.718" y2="18.669" width="0.1524" layer="16"/>
+<wire x1="29.718" y1="18.669" x2="24.7116" y2="18.669" width="0.1524" layer="16"/>
+<wire x1="24.7116" y1="18.669" x2="20.5206" y2="22.86" width="0.1524" layer="16"/>
 <wire x1="57.851" y1="16.002" x2="46.9192875" y2="16.002" width="0.1524" layer="16"/>
 <wire x1="46.9192875" y1="16.002" x2="44.1126875" y2="18.8086" width="0.1524" layer="16"/>
+<wire x1="38.1" y1="16.51" x2="40.3986" y2="18.8086" width="0.1524" layer="16"/>
 </signal>
 <signal name="N$31">
 <contactref element="U$1" pad="PIN36"/>
@@ -3420,14 +3419,21 @@ design rules under a new name.</description>
 <wire x1="20.36894375" y1="27.15" x2="20.5463625" y2="27.32741875" width="0.1524" layer="1"/>
 <wire x1="20.5463625" y1="27.32741875" x2="20.5768" y2="27.32741875" width="0.1524" layer="1"/>
 <wire x1="20.5768" y1="27.32741875" x2="20.828" y2="27.57861875" width="0.1524" layer="1"/>
-<wire x1="20.828" y1="27.57861875" x2="22.58638125" y2="27.57861875" width="0.1524" layer="16"/>
-<wire x1="38.801" y1="17.272" x2="40.071" y2="16.002" width="0.1524" layer="16"/>
-<wire x1="38.801" y1="17.272" x2="27.813" y2="17.272" width="0.1524" layer="16"/>
-<wire x1="25.63030625" y1="27.226" x2="25.956" y2="26.90030625" width="0.1524" layer="16"/>
-<wire x1="22.939" y1="27.226" x2="25.63030625" y2="27.226" width="0.1524" layer="16"/>
-<wire x1="25.956" y1="19.129" x2="27.813" y2="17.272" width="0.1524" layer="16"/>
-<wire x1="25.956" y1="26.90030625" x2="25.956" y2="19.129" width="0.1524" layer="16"/>
-<wire x1="22.58638125" y1="27.57861875" x2="22.939" y2="27.226" width="0.1524" layer="16"/>
+<wire x1="34.163" y1="15.748" x2="34.417" y2="15.494" width="0.1524" layer="16"/>
+<wire x1="34.163" y1="15.748" x2="34.163" y2="18.669" width="0.1524" layer="16"/>
+<wire x1="34.163" y1="18.669" x2="33.274" y2="19.558" width="0.1524" layer="16"/>
+<wire x1="33.274" y1="19.558" x2="31.369" y2="19.558" width="0.1524" layer="16"/>
+<wire x1="31.369" y1="19.558" x2="29.972" y2="18.161" width="0.1524" layer="16"/>
+<wire x1="29.972" y1="18.161" x2="24.384" y2="18.161" width="0.1524" layer="16"/>
+<wire x1="20.828" y1="27.57861875" x2="22.098" y2="26.30861875" width="0.1524" layer="16"/>
+<wire x1="22.098" y1="26.30861875" x2="22.098" y2="26.035" width="0.1524" layer="16"/>
+<wire x1="22.098" y1="26.035" x2="21.463" y2="25.4" width="0.1524" layer="16"/>
+<wire x1="21.463" y1="25.4" x2="19.812" y2="25.4" width="0.1524" layer="16"/>
+<wire x1="19.812" y1="25.4" x2="19.606" y2="25.194" width="0.1524" layer="16"/>
+<wire x1="19.606" y1="25.194" x2="19.606" y2="22.939" width="0.1524" layer="16"/>
+<wire x1="19.606" y1="22.939" x2="24.384" y2="18.161" width="0.1524" layer="16"/>
+<wire x1="39.563" y1="15.494" x2="40.071" y2="16.002" width="0.1524" layer="16"/>
+<wire x1="34.417" y1="15.494" x2="39.563" y2="15.494" width="0.1524" layer="16"/>
 </signal>
 <signal name="CSOUT">
 <contactref element="U$1" pad="PIN19"/>
@@ -3479,12 +3485,11 @@ design rules under a new name.</description>
 <wire x1="22.498" y1="24.023" x2="19.744" y2="24.023" width="0.1524" layer="1"/>
 <wire x1="19.744" y1="24.023" x2="19.617" y2="24.15" width="0.1524" layer="1"/>
 <wire x1="19.617" y1="24.15" x2="19.49" y2="24.15" width="0.1524" layer="1"/>
-<wire x1="22.86" y1="23.661" x2="23.329" y2="24.13" width="0.1524" layer="1"/>
-<wire x1="23.329" y1="24.13" x2="26.67" y2="24.13" width="0.1524" layer="1"/>
-<via x="26.67" y="24.13" extent="1-16" drill="0.35"/>
+<wire x1="22.86" y1="23.661" x2="22.86" y2="22.733" width="0.1524" layer="1"/>
+<via x="22.86" y="22.733" extent="1-16" drill="0.35"/>
 <contactref element="C18" pad="2"/>
-<wire x1="26.67" y1="24.13" x2="26.67" y2="19.05" width="0.1524" layer="16"/>
-<wire x1="26.67" y1="19.05" x2="27.6352" y2="18.0848" width="0.1524" layer="16"/>
+<wire x1="22.86" y1="22.733" x2="22.86" y2="21.1666" width="0.1524" layer="16"/>
+<wire x1="24.9766" y1="19.05" x2="22.86" y2="21.1666" width="0.1524" layer="16"/>
 <wire x1="61.849" y1="26.709" x2="61.849" y2="26.162" width="0.1524" layer="16"/>
 <via x="61.849" y="23.1928" extent="1-16" drill="0.35"/>
 <wire x1="61.849" y1="26.709" x2="61.849" y2="23.1928" width="0.1524" layer="16"/>
@@ -3519,10 +3524,15 @@ design rules under a new name.</description>
 <vertex x="84.963" y="30.099"/>
 <vertex x="46.228" y="30.099"/>
 </polygon>
-<wire x1="27.6352" y1="18.0848" x2="38.88849375" y2="18.0848" width="0.1524" layer="16"/>
-<wire x1="44.23894375" y1="19.1134" x2="44.30234375" y2="19.05" width="0.1524" layer="16"/>
-<wire x1="38.88849375" y1="18.0848" x2="39.91709375" y2="19.1134" width="0.1524" layer="16"/>
-<wire x1="39.91709375" y1="19.1134" x2="44.23894375" y2="19.1134" width="0.1524" layer="16"/>
+<wire x1="24.9766" y1="19.05" x2="29.464" y2="19.05" width="0.1524" layer="16"/>
+<wire x1="29.464" y1="19.05" x2="30.734" y2="20.32" width="0.1524" layer="16"/>
+<wire x1="30.734" y1="20.32" x2="34.036" y2="20.32" width="0.1524" layer="16"/>
+<wire x1="34.036" y1="20.32" x2="35.306" y2="19.05" width="0.1524" layer="16"/>
+<wire x1="35.306" y1="19.05" x2="39.37" y2="19.05" width="0.1524" layer="16"/>
+<wire x1="39.37" y1="19.05" x2="39.751" y2="19.431" width="0.1524" layer="16"/>
+<wire x1="39.751" y1="19.431" x2="44.831" y2="19.431" width="0.1524" layer="16"/>
+<wire x1="44.831" y1="19.431" x2="45.212" y2="19.05" width="0.1524" layer="16"/>
+<wire x1="45.212" y1="19.05" x2="47.498" y2="19.05" width="0.1524" layer="16"/>
 <via x="55.88" y="29.21" extent="1-16" drill="0.35"/>
 <via x="58.42" y="29.21" extent="1-16" drill="0.35"/>
 <via x="57.15" y="29.21" extent="1-16" drill="0.35"/>
@@ -3567,7 +3577,6 @@ design rules under a new name.</description>
 <wire x1="48.26" y1="19.812" x2="48.26" y2="21.59" width="0.1524" layer="1"/>
 <wire x1="48.26" y1="21.59" x2="48.436" y2="21.766" width="0.1524" layer="1"/>
 <wire x1="48.436" y1="21.766" x2="48.763" y2="21.766" width="0.1524" layer="1"/>
-<wire x1="44.30234375" y1="19.05" x2="47.498" y2="19.05" width="0.1524" layer="16"/>
 <wire x1="62.18" y1="20.211" x2="62.18" y2="22.051" width="0.1524" layer="1"/>
 <wire x1="62.18" y1="22.051" x2="62.18" y2="22.8618" width="0.1524" layer="1"/>
 <wire x1="62.18" y1="22.8618" x2="61.849" y2="23.1928" width="0.1524" layer="1"/>
@@ -3575,46 +3584,6 @@ design rules under a new name.</description>
 <wire x1="49.73" y1="22.733" x2="53.213" y2="22.733" width="0.1524" layer="1"/>
 <wire x1="59.055" y1="23.536" x2="59.69" y2="24.171" width="0.1524" layer="1"/>
 <wire x1="59.69" y1="24.171" x2="59.69" y2="25.4" width="0.1524" layer="1"/>
-</signal>
-<signal name="N$10">
-<contactref element="R33" pad="2"/>
-<contactref element="U$1" pad="PIN22"/>
-<wire x1="20.32" y1="16.51" x2="23.583" y2="13.247" width="0.1524" layer="16"/>
-<wire x1="29.8046875" y1="12.4684" x2="28.6153125" y2="12.4684" width="0.1524" layer="16"/>
-<wire x1="26.43969375" y1="13.256" x2="26.43069375" y2="13.247" width="0.1524" layer="16"/>
-<wire x1="23.583" y1="13.247" x2="26.43069375" y2="13.247" width="0.1524" layer="16"/>
-<wire x1="34.29" y1="13.247" x2="30.5832875" y2="13.247" width="0.1524" layer="16"/>
-<wire x1="30.5832875" y1="13.247" x2="29.8046875" y2="12.4684" width="0.1524" layer="16"/>
-<wire x1="28.6153125" y1="12.4684" x2="27.8277125" y2="13.256" width="0.1524" layer="16"/>
-<wire x1="27.8277125" y1="13.256" x2="26.43969375" y2="13.256" width="0.1524" layer="16"/>
-<wire x1="20.32" y1="16.51" x2="19.177" y2="16.51" width="0.1524" layer="16"/>
-<wire x1="19.177" y1="16.51" x2="17.018" y2="18.669" width="0.1524" layer="16"/>
-<via x="17.018" y="18.669" extent="1-16" drill="0.35"/>
-<wire x1="17.018" y1="18.669" x2="16.99" y2="18.697" width="0.1524" layer="1"/>
-<wire x1="16.99" y1="18.697" x2="16.99" y2="21.15" width="0.1524" layer="1"/>
-</signal>
-<signal name="N$20">
-<contactref element="R34" pad="2"/>
-<contactref element="U$1" pad="PIN21"/>
-<wire x1="16.49" y1="21.15" x2="16.51" y2="21.13" width="0.1524" layer="1"/>
-<wire x1="16.51" y1="19.05" x2="16.383" y2="18.923" width="0.1524" layer="1"/>
-<wire x1="16.673" y1="17.871" x2="16.673" y2="17.018" width="0.1524" layer="1"/>
-<via x="16.673" y="17.018" extent="1-16" drill="0.35"/>
-<wire x1="16.51" y1="21.13" x2="16.51" y2="19.05" width="0.1524" layer="1"/>
-<wire x1="16.383" y1="18.923" x2="16.383" y2="18.161" width="0.1524" layer="1"/>
-<wire x1="16.383" y1="18.161" x2="16.673" y2="17.871" width="0.1524" layer="1"/>
-<wire x1="16.673" y1="17.018" x2="17.018" y2="16.673" width="0.1524" layer="16"/>
-<wire x1="17.018" y1="16.673" x2="17.018" y2="14.732" width="0.1524" layer="16"/>
-<wire x1="17.018" y1="14.732" x2="17.78" y2="13.97" width="0.1524" layer="16"/>
-<wire x1="29.21" y1="13.247" x2="29.21" y2="13.97" width="0.1524" layer="16"/>
-<wire x1="29.21" y1="13.97" x2="27.94" y2="13.97" width="0.1524" layer="16"/>
-<via x="27.94" y="13.97" extent="1-16" drill="0.35"/>
-<wire x1="27.94" y1="13.97" x2="27.94" y2="12.827" width="0.1524" layer="1"/>
-<wire x1="27.94" y1="12.827" x2="26.67" y2="11.557" width="0.1524" layer="1"/>
-<via x="26.67" y="11.557" extent="1-16" drill="0.35"/>
-<wire x1="22.733" y1="11.557" x2="26.67" y2="11.557" width="0.1524" layer="16"/>
-<wire x1="17.78" y1="13.97" x2="20.32" y2="13.97" width="0.1524" layer="16"/>
-<wire x1="20.32" y1="13.97" x2="22.733" y2="11.557" width="0.1524" layer="16"/>
 </signal>
 <signal name="N$44">
 <contactref element="U$17" pad="A2"/>
@@ -3629,9 +3598,8 @@ design rules under a new name.</description>
 <wire x1="22.86" y1="19.47" x2="21.678" y2="19.47" width="0.1524" layer="1"/>
 <wire x1="19.49" y1="21.658" x2="19.49" y2="22.65" width="0.1524" layer="1"/>
 <wire x1="21.678" y1="19.47" x2="19.49" y2="21.658" width="0.1524" layer="1"/>
-<wire x1="25.4" y1="16.51" x2="22.86" y2="19.05" width="0.1524" layer="1"/>
-<wire x1="22.86" y1="19.47" x2="22.86" y2="19.05" width="0.1524" layer="1"/>
-<via x="25.4" y="16.51" extent="1-16" drill="0.35"/>
+<wire x1="22.86" y1="18.161" x2="22.86" y2="19.47" width="0.1524" layer="1"/>
+<via x="22.86" y="18.161" extent="1-16" drill="0.35"/>
 <wire x1="60.96" y1="11.75" x2="60.96" y2="11.43" width="0.1524" layer="1"/>
 <via x="61.849" y="9.4768" extent="1-16" drill="0.35"/>
 <wire x1="61.849" y1="11.43" x2="61.849" y2="9.4768" width="0.1524" layer="1"/>
@@ -3652,12 +3620,12 @@ design rules under a new name.</description>
 <wire x1="59.69" y1="11.43" x2="58.42" y2="11.43" width="0.1524" layer="1"/>
 <wire x1="58.42" y1="11.43" x2="57.15" y2="11.43" width="0.1524" layer="1"/>
 <wire x1="57.15" y1="11.43" x2="55.88" y2="11.43" width="0.1524" layer="1"/>
-<wire x1="25.4" y1="16.51" x2="26.43954375" y2="16.51" width="0.1524" layer="16"/>
+<wire x1="33.528" y1="18.415" x2="32.766" y2="19.177" width="0.1524" layer="16"/>
+<wire x1="32.766" y1="19.177" x2="31.877" y2="19.177" width="0.1524" layer="16"/>
+<wire x1="31.877" y1="19.177" x2="30.48" y2="17.78" width="0.1524" layer="16"/>
+<wire x1="30.48" y1="17.78" x2="23.241" y2="17.78" width="0.1524" layer="16"/>
+<wire x1="23.241" y1="17.78" x2="22.86" y2="18.161" width="0.1524" layer="16"/>
 <wire x1="49.53" y1="8.89" x2="49.42750625" y2="8.99249375" width="0.1524" layer="16"/>
-<wire x1="26.43954375" y1="16.51" x2="26.99554375" y2="15.954" width="0.1524" layer="16"/>
-<wire x1="37.63774375" y1="15.954" x2="26.99554375" y2="15.954" width="0.1524" layer="16"/>
-<wire x1="43.259" y1="10.33274375" x2="43.259" y2="9.62749375" width="0.1524" layer="16"/>
-<wire x1="37.63774375" y1="15.954" x2="43.259" y2="10.33274375" width="0.1524" layer="16"/>
 <via x="55.88" y="11.43" extent="1-16" drill="0.35"/>
 <via x="57.15" y="11.43" extent="1-16" drill="0.35"/>
 <via x="58.42" y="11.43" extent="1-16" drill="0.35"/>
@@ -3731,12 +3699,9 @@ design rules under a new name.</description>
 <via x="77.47" y="16.51" extent="1-16" drill="0.35"/>
 <via x="80.01" y="16.51" extent="1-16" drill="0.35"/>
 <via x="46.99" y="6.35" extent="1-16" drill="0.35"/>
-<wire x1="44.4754" y1="8.41109375" x2="44.4754" y2="7.3148875" width="0.1524" layer="16"/>
-<wire x1="44.4754" y1="7.3148875" x2="45.4402875" y2="6.35" width="0.1524" layer="16"/>
-<wire x1="45.4402875" y1="6.35" x2="46.99" y2="6.35" width="0.1524" layer="16"/>
+<wire x1="41.1734" y1="6.35" x2="46.99" y2="6.35" width="0.1524" layer="16"/>
 <wire x1="46.99" y1="6.35" x2="48.436" y2="7.796" width="0.1524" layer="1"/>
 <wire x1="48.436" y1="7.796" x2="48.763" y2="7.796" width="0.1524" layer="1"/>
-<wire x1="43.259" y1="9.62749375" x2="44.4754" y2="8.41109375" width="0.1524" layer="16"/>
 <wire x1="62.307" y1="6.241" x2="62.307" y2="8.081" width="0.1524" layer="1"/>
 <wire x1="62.307" y1="8.081" x2="62.307" y2="9.0188" width="0.1524" layer="1"/>
 <wire x1="62.307" y1="9.0188" x2="61.849" y2="9.4768" width="0.1524" layer="1"/>
@@ -3746,6 +3711,14 @@ design rules under a new name.</description>
 <wire x1="48.763" y1="10.83" x2="51.268" y2="13.335" width="0.1524" layer="1"/>
 <wire x1="59.055" y1="9.693" x2="59.782" y2="10.42" width="0.1524" layer="1"/>
 <wire x1="59.782" y1="10.42" x2="61.24" y2="10.42" width="0.1524" layer="1"/>
+<wire x1="33.528" y1="18.415" x2="33.528" y2="14.224" width="0.1524" layer="16"/>
+<wire x1="33.528" y1="14.224" x2="34.29" y2="13.462" width="0.1524" layer="16"/>
+<wire x1="34.29" y1="13.462" x2="35.687" y2="13.462" width="0.1524" layer="16"/>
+<wire x1="35.687" y1="13.462" x2="36.195" y2="12.954" width="0.1524" layer="16"/>
+<wire x1="36.195" y1="12.954" x2="36.195" y2="10.795" width="0.1524" layer="16"/>
+<wire x1="36.195" y1="10.795" x2="37.3634" y2="9.6266" width="0.1524" layer="16"/>
+<wire x1="37.3634" y1="9.6266" x2="41.1734" y2="9.6266" width="0.1524" layer="16"/>
+<wire x1="41.1734" y1="9.6266" x2="41.1734" y2="6.35" width="0.1524" layer="16"/>
 </signal>
 <signal name="N$5">
 <contactref element="F_C5" pad="P$2"/>
@@ -3808,7 +3781,6 @@ design rules under a new name.</description>
 <contactref element="C15" pad="2"/>
 <contactref element="C14" pad="2"/>
 <contactref element="C16" pad="2"/>
-<contactref element="R33" pad="1"/>
 <wire x1="17.49" y1="29.65" x2="17.49" y2="30.19" width="0.1524" layer="1"/>
 <wire x1="19.558" y1="32.258" x2="20.828" y2="32.258" width="0.1524" layer="1"/>
 <wire x1="17.49" y1="30.19" x2="19.558" y2="32.258" width="0.1524" layer="1"/>
@@ -3825,8 +3797,7 @@ design rules under a new name.</description>
 <wire x1="44.577" y1="26.328" x2="44.577" y2="24.13" width="0.1524" layer="16"/>
 <via x="44.577" y="23.876" extent="1-16" drill="0.35"/>
 <wire x1="44.577" y1="24.13" x2="44.577" y2="23.876" width="0.1524" layer="16"/>
-<wire x1="44.577" y1="23.876" x2="44.577" y2="24.13" width="0.1524" layer="1"/>
-<wire x1="44.577" y1="24.13" x2="44.577" y2="24.831" width="0.1524" layer="1"/>
+<wire x1="44.577" y1="23.876" x2="44.577" y2="24.831" width="0.1524" layer="1"/>
 <wire x1="44.577" y1="24.831" x2="43.848" y2="25.56" width="0.1524" layer="1"/>
 <wire x1="43.942" y1="12.385" x2="43.714" y2="12.157" width="0.1524" layer="1"/>
 <wire x1="43.714" y1="12.157" x2="43.714" y2="11.309" width="0.1524" layer="1"/>
@@ -3858,21 +3829,18 @@ design rules under a new name.</description>
 <wire x1="44.343" y1="39.37" x2="44.577" y2="39.37" width="0.1524" layer="1"/>
 <wire x1="43.968" y1="25.025" x2="43.847" y2="25.025" width="0.1524" layer="1"/>
 <wire x1="43.847" y1="25.025" x2="43.841" y2="25.019" width="0.1524" layer="1"/>
-<wire x1="34.124" y1="15.24" x2="33.147" y2="15.24" width="0.1524" layer="16"/>
-<via x="33.147" y="15.24" extent="1-16" drill="0.35"/>
-<wire x1="33.147" y1="15.24" x2="33.147" y2="16.637" width="0.1524" layer="1"/>
-<wire x1="33.147" y1="16.637" x2="34.163" y2="17.653" width="0.1524" layer="1"/>
-<wire x1="34.163" y1="17.653" x2="34.677" y2="17.653" width="0.1524" layer="1"/>
+<via x="32.131" y="18.415" extent="1-16" drill="0.35"/>
+<wire x1="34.677" y1="17.653" x2="32.893" y2="17.653" width="0.1524" layer="1"/>
+<wire x1="32.131" y1="18.415" x2="32.893" y2="17.653" width="0.1524" layer="1"/>
 <contactref element="R32" pad="1"/>
 <contactref element="R31" pad="1"/>
 <contactref element="R30" pad="1"/>
 <wire x1="53.442" y1="34.29" x2="44.45" y2="34.29" width="1.016" layer="16"/>
 <wire x1="44.45" y1="34.29" x2="44.45" y2="37.6708" width="1.016" layer="16"/>
 <wire x1="44.45" y1="37.6708" x2="44.577" y2="37.7978" width="1.016" layer="16"/>
-<wire x1="53.569" y1="20.193" x2="44.577" y2="20.193" width="1.016" layer="16"/>
-<wire x1="44.577" y1="20.193" x2="44.45" y2="20.32" width="1.016" layer="16"/>
-<wire x1="44.45" y1="20.32" x2="44.45" y2="24.003" width="1.016" layer="16"/>
-<wire x1="44.45" y1="24.003" x2="44.577" y2="24.13" width="1.016" layer="16"/>
+<wire x1="53.569" y1="20.193" x2="48.387" y2="20.193" width="1.016" layer="16"/>
+<wire x1="48.387" y1="20.193" x2="44.5135" y2="24.0665" width="1.016" layer="16"/>
+<wire x1="44.5135" y1="24.0665" x2="44.577" y2="24.13" width="1.016" layer="16"/>
 <wire x1="53.442" y1="7.493" x2="53.315" y2="7.62" width="1.016" layer="16"/>
 <wire x1="53.315" y1="7.62" x2="45.212" y2="7.62" width="1.016" layer="16"/>
 <wire x1="45.212" y1="7.62" x2="45.212" y2="10.6198" width="1.016" layer="16"/>
@@ -3888,6 +3856,14 @@ design rules under a new name.</description>
 <vertex x="35.941" y="9.271"/>
 <vertex x="35.941" y="13.081"/>
 <vertex x="32.639" y="13.081"/>
+<vertex x="32.639" y="16.129"/>
+<vertex x="33.02" y="16.51"/>
+<vertex x="33.655" y="16.51"/>
+<vertex x="33.782" y="16.637"/>
+<vertex x="33.782" y="18.923"/>
+<vertex x="33.655" y="19.05"/>
+<vertex x="33.02" y="19.05"/>
+<vertex x="32.639" y="19.431"/>
 </polygon>
 <polygon width="0.1524" layer="16" thermals="no">
 <vertex x="32.639" y="43.18"/>
@@ -3895,7 +3871,13 @@ design rules under a new name.</description>
 <vertex x="45.72" y="9.271"/>
 <vertex x="35.941" y="9.271"/>
 <vertex x="35.941" y="13.081"/>
-<vertex x="32.639" y="13.081"/>
+<vertex x="33.274" y="13.081"/>
+<vertex x="33.274" y="16.51"/>
+<vertex x="33.782" y="17.018"/>
+<vertex x="33.782" y="18.923"/>
+<vertex x="33.655" y="19.05"/>
+<vertex x="33.02" y="19.05"/>
+<vertex x="32.639" y="19.431"/>
 </polygon>
 <via x="39.37" y="24.13" extent="1-16" drill="0.35"/>
 <via x="39.37" y="41.91" extent="1-16" drill="0.35"/>
@@ -3917,11 +3899,9 @@ design rules under a new name.</description>
 <via x="36.83" y="29.21" extent="1-16" drill="0.35"/>
 <via x="39.37" y="22.86" extent="1-16" drill="0.35"/>
 <via x="38.1" y="22.86" extent="1-16" drill="0.35"/>
-<via x="39.37" y="21.59" extent="1-16" drill="0.35"/>
-<via x="38.1" y="21.59" extent="1-16" drill="0.35"/>
-<via x="36.83" y="20.32" extent="1-16" drill="0.35"/>
-<via x="39.37" y="20.32" extent="1-16" drill="0.35"/>
-<via x="38.1" y="19.05" extent="1-16" drill="0.35"/>
+<via x="38.1" y="24.13" extent="1-16" drill="0.35"/>
+<via x="36.83" y="22.86" extent="1-16" drill="0.35"/>
+<via x="36.83" y="24.13" extent="1-16" drill="0.35"/>
 <via x="41.91" y="13.97" extent="1-16" drill="0.35"/>
 <via x="39.37" y="12.7" extent="1-16" drill="0.35"/>
 <via x="39.37" y="11.43" extent="1-16" drill="0.35"/>
@@ -3940,6 +3920,15 @@ design rules under a new name.</description>
 <wire x1="44.577" y1="36.86" x2="44.577" y2="37.7978" width="0.1524" layer="1"/>
 <wire x1="44.781" y1="22.686" x2="44.577" y2="22.89" width="0.1524" layer="1"/>
 <wire x1="44.577" y1="22.89" x2="44.577" y2="23.876" width="0.1524" layer="1"/>
+<contactref element="U$1" pad="PIN22"/>
+<wire x1="17.018" y1="18.669" x2="19.177" y2="16.51" width="0.1524" layer="16"/>
+<via x="17.018" y="18.669" extent="1-16" drill="0.35"/>
+<wire x1="17.018" y1="18.669" x2="16.99" y2="18.697" width="0.1524" layer="1"/>
+<wire x1="16.99" y1="18.697" x2="16.99" y2="21.15" width="0.1524" layer="1"/>
+<wire x1="31.115" y1="17.399" x2="32.131" y2="18.415" width="0.1524" layer="16"/>
+<wire x1="19.177" y1="16.51" x2="22.352" y2="16.51" width="0.1524" layer="16"/>
+<wire x1="22.352" y1="16.51" x2="23.241" y2="17.399" width="0.1524" layer="16"/>
+<wire x1="23.241" y1="17.399" x2="31.115" y2="17.399" width="0.1524" layer="16"/>
 </signal>
 <signal name="N$42">
 <contactref element="U$26" pad="C"/>

--- a/bl_motor_dora3/bl_dora2.sch
+++ b/bl_motor_dora3/bl_dora2.sch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="9.4.2">
+<eagle version="9.5.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -396,18 +396,6 @@ Source: PANASONIC .. aoc0000ce1.pdf</description>
 <wire x1="7.4" y1="5.75" x2="7.4" y2="0" width="0.127" layer="21"/>
 <wire x1="7.4" y1="0" x2="0" y2="0" width="0.127" layer="21"/>
 </package>
-<package name="1608REG">
-<description>1608サイズのチップ抵抗　多分ガッコのリールチップ抵抗はこのサイズ</description>
-<wire x1="-0.356" y1="0.432" x2="0.356" y2="0.432" width="0.1016" layer="51"/>
-<wire x1="-0.356" y1="-0.419" x2="0.356" y2="-0.419" width="0.1016" layer="51"/>
-<smd name="1" x="-0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<smd name="2" x="0.85" y="0" dx="1.1" dy="1" layer="1"/>
-<rectangle x1="-0.8382" y1="-0.4699" x2="-0.3381" y2="0.4801" layer="51"/>
-<rectangle x1="0.3302" y1="-0.4699" x2="0.8303" y2="0.4801" layer="51"/>
-<rectangle x1="-0.1999" y1="-0.3" x2="0.1999" y2="0.3" layer="35"/>
-<text x="-1.27" y="1.27" size="0.4064" layer="25">&gt;NAME</text>
-<text x="-1.27" y="0.762" size="0.4064" layer="27">&gt;VALUE</text>
-</package>
 <package name="ES3BB13F" urn="urn:adsk.eagle:footprint:43181/1" locally_modified="yes">
 <description>&lt;B&gt;DIODE&lt;/B&gt;</description>
 <wire x1="-2.2606" y1="1.905" x2="2.2606" y2="1.905" width="0.1016" layer="21"/>
@@ -702,16 +690,6 @@ Source: PANASONIC .. aoc0000ce1.pdf</description>
 <wire x1="-2.54" y1="-7.62" x2="10.16" y2="-7.62" width="0.254" layer="95"/>
 <wire x1="10.16" y1="-7.62" x2="10.16" y2="7.62" width="0.254" layer="95"/>
 <wire x1="10.16" y1="7.62" x2="-2.54" y2="7.62" width="0.254" layer="95"/>
-</symbol>
-<symbol name="1608REG">
-<wire x1="-2.54" y1="-0.889" x2="2.54" y2="-0.889" width="0.254" layer="94"/>
-<wire x1="2.54" y1="0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
-<wire x1="2.54" y1="-0.889" x2="2.54" y2="0.889" width="0.254" layer="94"/>
-<wire x1="-2.54" y1="-0.889" x2="-2.54" y2="0.889" width="0.254" layer="94"/>
-<text x="-3.81" y="1.4986" size="1.778" layer="95">&gt;NAME</text>
-<text x="-3.81" y="-3.302" size="1.778" layer="96">&gt;VALUE</text>
-<pin name="2" x="5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1" rot="R180"/>
-<pin name="1" x="-5.08" y="0" visible="off" length="short" direction="pas" swaplevel="1"/>
 </symbol>
 <symbol name="ES3BB13F">
 <wire x1="-0.762" y1="1.016" x2="0" y2="-1.016" width="0.254" layer="94"/>
@@ -1028,23 +1006,6 @@ Source: PANASONIC .. aoc0000ce1.pdf</description>
 <connects>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 <connect gate="G$1" pin="P$2" pad="P$2"/>
-</connects>
-<technologies>
-<technology name=""/>
-</technologies>
-</device>
-</devices>
-</deviceset>
-<deviceset name="1608REG" prefix="R" uservalue="yes">
-<description>1608パッケージのチップ抵抗　ガッコのリールの抵抗はたぶんこれ</description>
-<gates>
-<gate name="G$1" symbol="1608REG" x="0" y="0"/>
-</gates>
-<devices>
-<device name="" package="1608REG">
-<connects>
-<connect gate="G$1" pin="1" pad="1"/>
-<connect gate="G$1" pin="2" pad="2"/>
 </connects>
 <technologies>
 <technology name=""/>
@@ -17809,8 +17770,6 @@ Source: http://products.nichicon.co.jp/en/pdf/XJA043/e-ud.pdf</description>
 <part name="C16" library="rcl" library_urn="urn:adsk.eagle:library:334" deviceset="C-EU" device="C2012" package3d_urn="urn:adsk.eagle:package:23625/2" value="5n"/>
 <part name="C17" library="rcl" library_urn="urn:adsk.eagle:library:334" deviceset="C-EU" device="C2012" package3d_urn="urn:adsk.eagle:package:23625/2" value="5n"/>
 <part name="C18" library="rcl" library_urn="urn:adsk.eagle:library:334" deviceset="C-EU" device="C2012" package3d_urn="urn:adsk.eagle:package:23625/2" value="5n"/>
-<part name="R33" library="user" deviceset="1608REG" device="" value="0"/>
-<part name="R34" library="user" deviceset="1608REG" device="" value="0"/>
 <part name="U$20" library="user" deviceset="ES3BB13F" device=""/>
 <part name="U$21" library="user" deviceset="ES3BB13F" device=""/>
 <part name="U$22" library="user" deviceset="ES3BB13F" device=""/>
@@ -18167,14 +18126,6 @@ Source: http://products.nichicon.co.jp/en/pdf/XJA043/e-ud.pdf</description>
 <attribute name="NAME" x="367.284" y="117.221" size="1.778" layer="95"/>
 <attribute name="VALUE" x="367.284" y="112.141" size="1.778" layer="96"/>
 </instance>
-<instance part="R33" gate="G$1" x="10.16" y="27.94" smashed="yes">
-<attribute name="NAME" x="1.27" y="29.4386" size="1.778" layer="95"/>
-<attribute name="VALUE" x="6.35" y="24.638" size="1.778" layer="96"/>
-</instance>
-<instance part="R34" gate="G$1" x="10.16" y="22.86" smashed="yes">
-<attribute name="NAME" x="1.27" y="24.3586" size="1.778" layer="95"/>
-<attribute name="VALUE" x="6.35" y="19.558" size="1.778" layer="96"/>
-</instance>
 <instance part="U$20" gate="G$1" x="330.2" y="116.84" smashed="yes">
 <attribute name="NAME" x="328.8284" y="114.3" size="1.778" layer="95" rot="R90"/>
 <attribute name="VALUE" x="333.4004" y="114.3" size="1.778" layer="96" rot="R90"/>
@@ -18248,8 +18199,11 @@ Source: http://products.nichicon.co.jp/en/pdf/XJA043/e-ud.pdf</description>
 <junction x="-7.62" y="20.32"/>
 <pinref part="GND2" gate="1" pin="GND"/>
 <junction x="2.54" y="20.32"/>
-<pinref part="R34" gate="G$1" pin="1"/>
 <wire x1="2.54" y1="20.32" x2="5.08" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="22.86" x2="17.78" y2="27.94" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="PIN21_CSN"/>
+<wire x1="17.78" y1="27.94" x2="20.32" y2="27.94" width="0.1524" layer="91"/>
+<wire x1="17.78" y1="22.86" x2="5.08" y2="22.86" width="0.1524" layer="91"/>
 </segment>
 <segment>
 <pinref part="C11" gate="G$1" pin="2"/>
@@ -19166,24 +19120,6 @@ Source: http://products.nichicon.co.jp/en/pdf/XJA043/e-ud.pdf</description>
 <junction x="388.62" y="71.12"/>
 </segment>
 </net>
-<net name="N$10" class="0">
-<segment>
-<pinref part="R33" gate="G$1" pin="2"/>
-<wire x1="15.24" y1="27.94" x2="15.24" y2="25.4" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PIN22_CSP"/>
-<wire x1="15.24" y1="25.4" x2="20.32" y2="25.4" width="0.1524" layer="91"/>
-<wire x1="20.32" y1="25.4" x2="20.32" y2="22.86" width="0.1524" layer="91"/>
-</segment>
-</net>
-<net name="N$20" class="0">
-<segment>
-<pinref part="R34" gate="G$1" pin="2"/>
-<wire x1="15.24" y1="22.86" x2="17.78" y2="22.86" width="0.1524" layer="91"/>
-<wire x1="17.78" y1="22.86" x2="17.78" y2="27.94" width="0.1524" layer="91"/>
-<pinref part="U$1" gate="G$1" pin="PIN21_CSN"/>
-<wire x1="17.78" y1="27.94" x2="20.32" y2="27.94" width="0.1524" layer="91"/>
-</segment>
-</net>
 <net name="N$44" class="0">
 <segment>
 <pinref part="U$17" gate="G$1" pin="A2"/>
@@ -19342,7 +19278,6 @@ Source: http://products.nichicon.co.jp/en/pdf/XJA043/e-ud.pdf</description>
 <pinref part="C16" gate="G$1" pin="2"/>
 <wire x1="414.02" y1="48.26" x2="416.56" y2="45.72" width="0.1524" layer="91"/>
 <junction x="416.56" y="45.72"/>
-<pinref part="R33" gate="G$1" pin="1"/>
 <wire x1="2.54" y1="30.48" x2="5.08" y2="27.94" width="0.1524" layer="91"/>
 <junction x="2.54" y="30.48"/>
 <wire x1="434.34" y1="53.34" x2="429.26" y2="53.34" width="0.1524" layer="91"/>
@@ -19367,6 +19302,11 @@ Source: http://products.nichicon.co.jp/en/pdf/XJA043/e-ud.pdf</description>
 <wire x1="447.04" y1="76.2" x2="447.04" y2="45.72" width="0.1524" layer="91"/>
 <wire x1="447.04" y1="45.72" x2="429.26" y2="45.72" width="0.1524" layer="91"/>
 <junction x="429.26" y="45.72"/>
+<wire x1="15.24" y1="27.94" x2="15.24" y2="25.4" width="0.1524" layer="91"/>
+<pinref part="U$1" gate="G$1" pin="PIN22_CSP"/>
+<wire x1="15.24" y1="25.4" x2="20.32" y2="25.4" width="0.1524" layer="91"/>
+<wire x1="20.32" y1="25.4" x2="20.32" y2="22.86" width="0.1524" layer="91"/>
+<wire x1="5.08" y1="27.94" x2="15.24" y2="27.94" width="0.1524" layer="91"/>
 </segment>
 </net>
 <net name="N$42" class="0">


### PR DESCRIPTION
## 1. シャントの配線をしっかり切り分ける。
![キャプチャ](https://user-images.githubusercontent.com/26002398/94717619-8fa19180-038b-11eb-8fec-c76d2f4b1003.PNG)

## 2. bottomのGNDを横切る配線をまとめる
注：　上のグランドのベタはもう少し下に下げてもいい。信号線間にGNDの仕切りを付けた方がいいかもしれない（上からviaを通してlineで切る）。ただし、シャントのPとNは完全にくっつける
![キャプチャ2](https://user-images.githubusercontent.com/26002398/94717783-bc55a900-038b-11eb-9b85-26c4522d29f9.PNG)

## 3. ビアの数を減らす
こっちの上側の配線はもうすこしきれいにできる（疲れた
![キャプチャ3](https://user-images.githubusercontent.com/26002398/94718061-1eaea980-038c-11eb-99b8-80204991deb6.PNG)
